### PR TITLE
Update GOLANG base image & Improve documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14
+FROM golang:1.22
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ jobs:
     runs-on: ubuntu-latest
     name: Validate atlantis.yaml
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Ensure atlantis.yaml is up to date using terragrunt-atlantis-config
         id: atlantis_validator
-        uses: transcend-io/terragrunt-atlantis-config-github-action@v0.0.3
+        uses: transcend-io/terragrunt-atlantis-config-github-action@v0.0.5
         with:
           version: v0.5.0
-          extra_args: '--autoplan --parallel=false
+          extra_args: '--autoplan --parallel=false'
 ```
 
 If you want to save money on billable minutes, you could update to run on pull requests instead of each push

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 # Install the tool
 export GO111MODULE=on
-go get "github.com/transcend-io/terragrunt-atlantis-config@$1"
+go install "github.com/transcend-io/terragrunt-atlantis-config@$1"
 
 # Generate what the config should look like
 shift


### PR DESCRIPTION
Hello there,
the current version of the action is not able to run newer versions of terragrunt-atlantis-config (e.g. `v1.19.0` in our case) because most likely the underlying go version is too old.
This PR uses a more recent version of golang (1.23 is just released, so I decided to go for 1.22). In this step I moved from `go get` to `go install` to match your installation documentation. 
Additionally, I fixed slightly the README and corrected a small typo